### PR TITLE
Expose SQLiteError and Problem

### DIFF
--- a/Sources/SQLite/Database/SQLiteError.swift
+++ b/Sources/SQLite/Database/SQLiteError.swift
@@ -2,11 +2,11 @@ import CSQLite
 import Debugging
 
 /// Errors that can be thrown while using SQLite
-struct SQLiteError: Debuggable {
-    let problem: Problem
+public struct SQLiteError: Debuggable {
+    public let problem: Problem
     public let reason: String
-    var sourceLocation: SourceLocation?
-    public var stackTrace: [String]
+    public let sourceLocation: SourceLocation?
+    public let stackTrace: [String]
     public var identifier: String {
         return problem.rawValue
     }
@@ -37,7 +37,7 @@ struct SQLiteError: Debuggable {
 }
 
 /// Problem kinds.
-internal enum Problem: String {
+public enum Problem: String {
     case error
     case intern
     case permission


### PR DESCRIPTION
When using FluentSQLite, the raw SQLiteError ends up getting propagated all the way up to the caller, which is usually a route. If you need to know what kind of error occurred (eg if it was specifically a unique constraint violation in order to implement concurrency-safe model creation), the only way currently is to do string matching on the error's description, which is shoddy, error-prone, and fragile. 

With the error type public, you can do

```swift
if let error = error as? SQLiteError, case .constraint = error { 
  /* handle UNIQUE constraint violation */ 
}
```
This is much cleaner. (This PR also changes the properties to `let`s because they don't need to be `var` in the first place, which is just good style)

There is a FluentSQLiteError type, but not only does it not preserve any of these specifics, it never actually gets thrown!