### PR TITLE
Fix identifier quote

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/sqlite-nio.git", .branch("master")),
-        .package(url: "https://github.com/rnantes/sql-kit.git", .branch("master")),
+        .package(url: "https://github.com/vapor/sql-kit.git", .branch("master")),
         .package(url: "https://github.com/vapor/async-kit.git", .branch("master")),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/sqlite-nio.git", .branch("master")),
-        .package(url: "https://github.com/vapor/sql-kit.git", .branch("master")),
+        .package(url: "https://github.com/rnantes/sql-kit.git", .branch("master")),
         .package(url: "https://github.com/vapor/async-kit.git", .branch("master")),
     ],
     targets: [

--- a/Sources/SQLiteKit/SQLiteDialect.swift
+++ b/Sources/SQLiteKit/SQLiteDialect.swift
@@ -4,11 +4,11 @@ public struct SQLiteDialect: SQLDialect {
     }
     
     public var identifierQuote: SQLExpression {
-        return SQLRaw("'")
+        return SQLRaw("\"")
     }
 
     public var literalStringQuote: SQLExpression {
-        return SQLRaw("\"")
+        return SQLRaw("'")
     }
 
     public var autoIncrementClause: SQLExpression {


### PR DESCRIPTION
Fixed identifierQuote and literalStringQuote correcting serialized sql.
Example:
Old: 
`SELECT * FROM 'planets' WHERE 'name' = 'earth'`

Fixed:
`SELECT * FROM "planets" WHERE "name" = 'earth'`
