### PR TITLE
Propagate the minimal iOS 11 version requirement of SQLiteNIO to SQLiteKit

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,8 @@ import PackageDescription
 let package = Package(
     name: "sqlite-kit",
     platforms: [
-       .macOS(.v10_14)
+       .macOS(.v10_14),
+       .iOS(.v11)
     ],
     products: [
         .library(name: "SQLiteKit", targets: ["SQLiteKit"]),


### PR DESCRIPTION
Currently, SQLiteKit cannot build on iOS because SQLiteNIO requires at least iOS 11 when SQLiteKit has no specific requirement