### PR TITLE
Make tests respect the LOG_LEVEL env var

### DIFF
--- a/Tests/SQLiteKitTests/SQLKitTests.swift
+++ b/Tests/SQLiteKitTests/SQLKitTests.swift
@@ -127,10 +127,14 @@ class SQLiteTests: XCTestCase {
     }
 }
 
+func env(_ name: String) -> String? {
+    getenv(name).flatMap { String(cString: $0) }
+}
+
 let isLoggingConfigured: Bool = {
     LoggingSystem.bootstrap { label in
         var handler = StreamLogHandler.standardOutput(label: label)
-        handler.logLevel = .trace
+        handler.logLevel = env("LOG_LEVEL").flatMap { Logger.Level(rawValue: $0) } ?? .debug
         return handler
     }
     return true


### PR DESCRIPTION
No semvar label needed, this doesn't need a release posted for it.