### PR TITLE
SQLiteRow.decodeNil check value

### DIFF
--- a/Sources/SQLiteKit/SQLiteRow+SQLRow.swift
+++ b/Sources/SQLiteKit/SQLiteRow+SQLRow.swift
@@ -4,7 +4,10 @@ extension SQLiteRow: SQLRow {
     }
 
     public func decodeNil(column: String) throws -> Bool {
-        self.columns.offsets.keys.contains(column)
+        guard let data = self.column(column) else {
+            throw MissingColumn(column: column)
+        }
+        return data == .null
     }
 
     public func contains(column: String) -> Bool {


### PR DESCRIPTION
Adds a missing check to ensure the value is not `.null` when calling `SQLiteRow.decodeNil` (#82).