### PR TITLE
Support multiple in-memory databases

### DIFF
--- a/Sources/SQLiteKit/SQLiteConfiguration.swift
+++ b/Sources/SQLiteKit/SQLiteConfiguration.swift
@@ -16,13 +16,17 @@ public struct SQLiteConfiguration {
         case memory(identifier: String)
 
         /// Uses the SQLite database file at the specified path.
+        ///
         /// Non-absolute paths will check the current working directory.
         case file(path: String)
     }
 
     public var storage: Storage
+
+    /// If `true`, foreign keys will be enabled automatically on new connections.
     public var enableForeignKeys: Bool
 
+    /// Creates a new `SQLiteConfiguration`.
     public init(storage: Storage, enableForeignKeys: Bool = true) {
         self.storage = storage
         self.enableForeignKeys = enableForeignKeys

--- a/Sources/SQLiteKit/SQLiteConfiguration.swift
+++ b/Sources/SQLiteKit/SQLiteConfiguration.swift
@@ -1,0 +1,30 @@
+import struct Foundation.UUID
+
+public struct SQLiteConfiguration {
+    public enum Storage {
+        /// Stores the SQLite database in memory.
+        /// 
+        /// Uses a randomly generated identifier. See `memory(identifier:)`.
+        public static var memory: Self {
+            .memory(identifier: UUID().uuidString)
+        }
+
+        /// Stores the SQLite database in memory.
+        /// - parameters:
+        ///     - identifier: Uniquely identifies the in-memory storage.
+        ///                   Connections using the same identifier share data.
+        case memory(identifier: String)
+
+        /// Uses the SQLite database file at the specified path.
+        /// Non-absolute paths will check the current working directory.
+        case file(path: String)
+    }
+
+    public var storage: Storage
+    public var enableForeignKeys: Bool
+
+    public init(storage: Storage, enableForeignKeys: Bool = true) {
+        self.storage = storage
+        self.enableForeignKeys = enableForeignKeys
+    }
+}

--- a/Sources/SQLiteKit/SQLiteConnectionSource.swift
+++ b/Sources/SQLiteKit/SQLiteConnectionSource.swift
@@ -6,14 +6,12 @@ public struct SQLiteConnectionSource: ConnectionPoolSource {
 
     private var connectionStorage: SQLiteConnection.Storage {
         switch self.configuration.storage {
-        case .memory:
+        case .memory(let identifier):
             return .file(
-                path: "file:\(ObjectIdentifier(threadPool).unique)?mode=memory&cache=shared"
+                path: "file:\(identifier)?mode=memory&cache=shared"
             )
         case .file(let path):
             return .file(path: path)
-        case .connection(let storage):
-            return storage
         }
     }
     
@@ -45,34 +43,4 @@ public struct SQLiteConnectionSource: ConnectionPoolSource {
     }
 }
 
-public struct SQLiteConfiguration {
-    public enum Storage {
-        case memory
-        case file(path: String)
-        case connection(SQLiteConnection.Storage)
-    }
-
-    public var storage: Storage
-    public var enableForeignKeys: Bool
-
-    public init(storage: Storage, enableForeignKeys: Bool = true) {
-        self.storage = storage
-        self.enableForeignKeys = enableForeignKeys
-    }
-}
-
 extension SQLiteConnection: ConnectionPoolItem { }
-
-
-private extension ObjectIdentifier {
-    var unique: String {
-        let raw = "\(self)"
-        let parts = raw.split(separator: "(")
-        switch parts.count {
-        case 2:
-            return parts[1].split(separator: ")").first.flatMap(String.init) ?? raw
-        default:
-            return raw
-        }
-    }
-}


### PR DESCRIPTION
Adds a new parameter `identifier` to `SQLiteConfiguration.Storage.memory` (#86, fixes #79). 

This string uniquely identifies the in-memory database. Connections that use the same memory identifier share data. 

```swift
let configuration = SQLiteConfiguration(storage: .memory(identifier: "foo"))
```

Using `.memory` without specifying an identifier will generate a random value. Only connections using that specific configuration will share data. This means multiple connection sources can now be initialized with separate configuration structs in the same process. 