### PR TITLE
add minimum ios version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,8 @@ import PackageDescription
 let package = Package(
     name: "sqlite-kit",
     platforms: [
-       .macOS(.v10_15)
+       .macOS(.v10_15),
+       .iOS(.v13),
     ],
     products: [
         .library(name: "SQLiteKit", targets: ["SQLiteKit"]),


### PR DESCRIPTION
this allows the package to build and run in ios 13+, there might be more support to do for watch, or other platforms, but I think best to wait until somebody comes across the issue and can test it

for now, this seems to be building and running