### PR TITLE
Switch to reusable CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,47 +9,12 @@ env:
 
 jobs:
 
-  codecov:
-    runs-on: ubuntu-latest
-    container: swift:5.7-jammy
-    steps:
-      # N.B.: When we switch to embedded SQLite, these first two steps should be removed,
-      # and the version saved to the environment should come from the checked-out package.
-      - name: Install libsqlite3 dependency
-        run: apt-get -q update && apt-get -q install -y libsqlite3-dev
-      - name: Save SQLite version to env
-        run: |
-          echo SQLITE_VERSION="$(pkg-config --modversion sqlite3)" >> $GITHUB_ENV
-      - name: Check out package
-        uses: actions/checkout@v3
-      - name: Run local tests with coverage
-        run: swift test --enable-code-coverage
-      - name: Submit coverage report to Codecov.io
-        uses: vapor/swift-codecov-action@v0.2
-        with:
-          cc_flags: 'unittests'
-          cc_env_vars: 'SWIFT_VERSION,SWIFT_PLATFORM,RUNNER_OS,RUNNER_ARCH,SQLITE_VERSION'
-          cc_fail_ci_if_error: true
-          cc_verbose: true
-          cc_dry_run: false
-
-  # Check for API breakage versus main
-  api-breakage:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    container: swift:5.7-jammy
-    steps:
-      - name: Install libsqlite3 dependency
-        run: apt-get -q update && apt-get -q install -y libsqlite3-dev
-      - name: Check out package
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      # https://github.com/actions/checkout/issues/766
-      - name: Mark the workspace as safe
-        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
-      - name: Check for API breaking changes
-        run: swift package diagnose-api-breaking-changes origin/main
+  # also serves as code coverage baseline update
+  unit-tests:
+    uses: vapor/ci/.github/workflows/run-unit-tests.yml@reusable-workflows
+    with:
+      with_coverage: true
+      with_tsan: false
 
   # Make sure downstream dependents still work
   dependents-check:
@@ -57,8 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     container: swift:5.7-jammy
     steps:
-      - name: Install libsqlite3 dependency
-        run: apt-get -q update && apt-get -q install -y libsqlite3-dev
       - name: Check out package
         uses: actions/checkout@v3
         with:
@@ -69,61 +32,6 @@ jobs:
           repository: vapor/fluent-sqlite-driver
           path: fluent-sqlite-driver
       - name: Tell dependents to use local checkout
-        run: 'swift package --package-path fluent-sqlite-driver edit sqlite-kit --path sqlite-kit'
+        run: swift package --package-path fluent-sqlite-driver edit sqlite-kit --path sqlite-kit
       - name: Run FluentSQLiteDriver tests with Thread Sanitizer
         run: swift test --package-path fluent-sqlite-driver --sanitize=thread
-
-  # Run unit tests (Linux)
-  linux-unit:
-    if: github.event_name == 'pull_request'
-    strategy:
-      fail-fast: false
-      matrix:
-        runner:
-          - swift:5.5-bionic
-          - swift:5.6-focal
-          - swift:5.7-jammy
-          - swiftlang/swift:nightly-main-jammy
-    container: ${{ matrix.runner }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install libsqlite3 dependency
-        run: apt-get -q update && apt-get -q install -y libsqlite3-dev
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: Run tests with Thread Sanitizer
-        run: swift test --sanitize=thread
-
-
-  # Run unit tests (macOS).
-  macos-unit:
-    if: github.event_name == 'pull_request'
-    strategy:
-      fail-fast: false
-      matrix:
-        macos:
-          - macos-11
-          - macos-12
-        xcode:
-          - latest-stable
-    runs-on: ${{ matrix.macos }}
-    steps:
-      - name: Select latest available Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with: 
-          xcode-version: ${{ matrix.xcode }}
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: Run tests with Thread Sanitizer
-        run: swift test --sanitize=thread
-
-  test-exports:
-    name: Test exports
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out Vapor
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Build
-        run: swift build -Xswiftc -DBUILDING_DOCC


### PR DESCRIPTION
Since we no longer need the extra dependency for SQLite3