### PR TITLE
Add SQLite support for nested subpath (JSON) expressions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/sqlite-nio.git", from: "1.2.0"),
-        .package(url: "https://github.com/vapor/sql-kit.git", from: "3.19.0"),
+        .package(url: "https://github.com/vapor/sql-kit.git", from: "3.28.0"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.14.0"),
     ],
     targets: [

--- a/Sources/SQLiteKit/SQLiteDialect.swift
+++ b/Sources/SQLiteKit/SQLiteDialect.swift
@@ -34,6 +34,15 @@ public struct SQLiteDialect: SQLDialect {
         return nil
     }
 
+    public func nestedSubpathExpression(in column: any SQLExpression, for path: [String]) -> (any SQLExpression)? {
+        guard !path.isEmpty else { return nil }
+        
+        return SQLFunction("json_extract", args: [
+            column,
+            SQLLiteral.string("$.\(path.joined(separator: "."))")
+        ])
+    }
+
     public init() { }
     
     private func isAtLeastVersion(_ major: Int, _ minor: Int, _ patch: Int) -> Bool {


### PR DESCRIPTION
Implements SQLKit's new `SQLDialect.nestedSubpathExpression(in:for:)` method.