### PR TITLE
Make nil decoding handling for SQLiteRows consistent with the other drivers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
   dependents-check:
     if: ${{ !(github.event.pull_request.draft || false) }}
     runs-on: ubuntu-latest
-    container: swift:5.8-jammy
+    container: swift:5.9-jammy
     steps:
       - name: Check out package
         uses: actions/checkout@v4

--- a/Sources/SQLiteKit/SQLiteRow+SQLRow.swift
+++ b/Sources/SQLiteKit/SQLiteRow+SQLRow.swift
@@ -8,7 +8,7 @@ extension SQLiteRow: SQLRow {
 
     public func decodeNil(column: String) throws -> Bool {
         guard let data = self.column(column) else {
-            throw MissingColumn(column: column)
+            return true
         }
         return data == .null
     }

--- a/Tests/SQLiteKitTests/SQLiteKitTests.swift
+++ b/Tests/SQLiteKitTests/SQLiteKitTests.swift
@@ -176,13 +176,13 @@ final class SQLiteKitTests: XCTestCase {
         XCTAssertEqual(try row1.decode(column: "value", as: String?.self), "abc")
         XCTAssertThrowsError(try row1.decode(column: "value", as: Int.self))
         XCTAssertThrowsError(try row1.decode(column: "nonexistent", as: String?.self))
-        XCTAssertThrowsError(try row1.decodeNil(column: "nonexistent"))
+        XCTAssertTrue(try row1.decodeNil(column: "nonexistent"))
         XCTAssertTrue(row2.contains(column: "value"))
         XCTAssertTrue(try row2.decodeNil(column: "value"))
         XCTAssertEqual(try row2.decode(column: "value", as: String?.self), nil)
         XCTAssertThrowsError(try row2.decode(column: "value", as: Int.self))
         XCTAssertThrowsError(try row2.decode(column: "nonexistent", as: String?.self))
-        XCTAssertThrowsError(try row2.decodeNil(column: "nonexistent"))
+        XCTAssertTrue(try row2.decodeNil(column: "nonexistent"))
     }
     
     func testRowEncoding() async throws {


### PR DESCRIPTION
Dating back to the original release of Fluent 4, the MySQL and Postgres SQLKit drivers ([mysql-kit](https://github.com/vapor/mysql-kit) and [postgres-kit](https://github.com/vapor/postgres-kit)) have always returned `true` from `SQLRow.decodeNil(column:)` when the column is not present, whereas the SQLite driver has thrown an error. This PR finally brings SQLite in line with the others.