### PR TITLE
Fix a DocC warning and update SQLiteNIO required version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
-        .package(url: "https://github.com/vapor/sqlite-nio.git", from: "1.8.4"),
+        .package(url: "https://github.com/vapor/sqlite-nio.git", from: "1.9.0"),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.29.3"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.19.0"),
     ],

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
-        .package(url: "https://github.com/vapor/sqlite-nio.git", from: "1.8.4"),
+        .package(url: "https://github.com/vapor/sqlite-nio.git", from: "1.9.0"),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.29.3"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.19.0"),
     ],

--- a/Sources/SQLiteKit/SQLiteDialect.swift
+++ b/Sources/SQLiteKit/SQLiteDialect.swift
@@ -1,6 +1,6 @@
 import SQLKit
 
-/// The ``SQLDialect`` defintions for SQLite.
+/// The `SQLDialect` defintions for SQLite.
 ///
 /// > Note: There is only ever one SQLite library in use by SQLiteNIO in any given process (even if there are
 /// > other versions of the library being used by other things). As such, there is no need for the dialect to


### PR DESCRIPTION
One can't use symbol links across modules. Also requires the most recent SQLiteNIO, since we made changes based on improvements therein in the last PR.